### PR TITLE
chore(deployments): add txtx runbooks to enhance protocol deployment

### DIFF
--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -1,0 +1,82 @@
+# Circle's Stablecoin EVM Runbooks
+
+[![Txtx](https://img.shields.io/badge/Operated%20with-Txtx-gree?labelColor=gray)](https://txtx.sh)
+
+## Available Runbooks
+
+`txtx` Runbooks are the perfect companion to Foundry + Hardhat when creating
+Solidity smart contracts. Foundry + Hardhat shine in making the development
+process a breeze; `txtx` makes deploying and operating on your contracts secure,
+simple, and reproducible.
+
+The following Runbooks are available for this project.
+
+### Deploy Fiat Token V2_2 Contract
+
+This Runbook deploys the `FiatToken_V2_2` and or the `FiatTokenCelloV2_2`
+contract, depending on the selected environment.
+
+The following table summarizes the possible environments and their impact:
+
+| Env            | Impact                                                                                                                                                         |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fiat-devnet`  | Deploys & initializes the `FiatTokenV2_2` contract on a local devnet.                                                                                          |
+| `fiat-mainnet` | Initializes the `FiatTokenV2_2` contract on mainnet Expects the contract to already be deployed, and for the env variables to supply the contract address.     |
+| `celo-devnet`  | Deploys & initializes the `FiatTokenCeloV2_2` contract on a local devnet.                                                                                      |
+| `celo-mainnet` | Initializes the `FiatTokenCeloV2_2` contract on mainnet Expects the contract to already be deployed, and for the env variables to supply the contract address. |
+
+To execute, run:
+
+```console
+txtx run deploy -u --env <env>
+```
+
+## Getting Started
+
+This repository is using [txtx](https://txtx.sh) for handling its on-chain
+operations.
+
+`txtx` takes its inspiration from a battle tested devops best practice named
+`infrastructure as code`, that have transformed cloud architectures.
+
+### Installation
+
+#### macOS
+
+```console
+brew tap txtx/txtx
+brew install txtx
+```
+
+#### Linux
+
+```console
+sudo snap install txtx
+```
+
+### List runbooks available in this repository
+
+```console
+$ txtx ls
+ID                                      Name                                    Description
+deploy                                  deploy                                  Deploys the Fiat Token or Fiat Token Celo contracts. Use environment CLI args to specify the network + contracts to deploy.
+```
+
+### Scaffold a new runbook
+
+```console
+$ txtx new
+```
+
+Access tutorials and documentation at [docs.txtx.sh](https://docs.txtx.sh) to
+understand the syntax and discover the powerful features of txtx.
+
+Additionally, the
+[Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=txtx.txtx)
+will make writing runbooks easier.
+
+### Execute an existing runbook
+
+```console
+$ txtx run <runbook-id>
+```

--- a/runbooks/deployments/deploy-fiat-token/main.tx
+++ b/runbooks/deployments/deploy-fiat-token/main.tx
@@ -8,6 +8,7 @@ signer "deployer" "evm::secret_key" {
 }
 
 action "deploy_fiat_token_proxy" "evm::deploy_contract" {
+    description = "Deploy the FiatTokenProxy contract"
     contract = evm::get_contract_from_foundry_project("FiatTokenProxy")
     constructor_args = [
         variable.fiat_token_v2_2_address
@@ -16,6 +17,7 @@ action "deploy_fiat_token_proxy" "evm::deploy_contract" {
 }
 
 action "deploy_master_minter" "evm::deploy_contract" {
+    description = "Deploy the MasterMinter contract"
     contract = evm::get_contract_from_foundry_project("MasterMinter")
     constructor_args = [
         action.deploy_fiat_token_proxy.contract_address
@@ -24,6 +26,7 @@ action "deploy_master_minter" "evm::deploy_contract" {
 }
 
 action "transfer_minter_ownership" "evm::call_contract" {
+    description = "Transfer ownership of the MasterMinter contract to the master minter owner"
     contract_address = action.deploy_master_minter.contract_address
     contract_abi = action.deploy_master_minter.abi
     function_name = "transferOwnership"
@@ -34,6 +37,7 @@ action "transfer_minter_ownership" "evm::call_contract" {
 }
 
 action "change_proxy_admin" "evm::call_contract" {
+    description = "Change the admin of the FiatTokenProxy contract"
     contract_address = action.deploy_fiat_token_proxy.contract_address
     contract_abi = action.deploy_fiat_token_proxy.abi
     function_name = "changeAdmin"
@@ -43,15 +47,11 @@ action "change_proxy_admin" "evm::call_contract" {
     signer = signer.deployer
 }
 
-action "deploy_fiat_token" "evm::deploy_contract" {
-    contract = evm::get_contract_from_foundry_project(variable.fiat_token_contract_name)
-    signer = signer.deployer
-
-}
 
 action "initialize" "evm::call_contract" {
-    contract_address = action.deploy_fiat_token.contract_address
-    contract_abi = action.deploy_fiat_token.abi
+    description = "Call the initialize function of the FiatToken contract via the proxy"
+    contract_address = action.deploy_fiat_token_proxy.contract_address
+    contract_abi = variable.fiat_token_contract.abi
     function_name = "initialize"
     function_args = [
         input.token_name,
@@ -64,12 +64,12 @@ action "initialize" "evm::call_contract" {
         evm::address(input.owner)
     ]
     signer = signer.deployer
-    // depends_on = [action.deploy_fiat_token]
 }
 
 action "initialize_v2" "evm::call_contract" {
-    contract_address = action.deploy_fiat_token.contract_address
-    contract_abi = action.deploy_fiat_token.abi
+    description = "Call the initializeV2 function of the FiatToken contract via the proxy"
+    contract_address = action.deploy_fiat_token_proxy.contract_address
+    contract_abi = variable.fiat_token_contract.abi
     function_name = "initializeV2"
     function_args = [
         input.token_name,
@@ -79,8 +79,9 @@ action "initialize_v2" "evm::call_contract" {
 }
 
 action "initialize_v2_1" "evm::call_contract" {
-    contract_address = action.deploy_fiat_token.contract_address
-    contract_abi = action.deploy_fiat_token.abi
+    description = "Call the initializeV2_1 function of the FiatToken contract via the proxy"
+    contract_address = action.deploy_fiat_token_proxy.contract_address
+    contract_abi = variable.fiat_token_contract.abi
     function_name = "initializeV2_1"
     function_args = [
         evm::address(input.lost_and_found)
@@ -90,8 +91,9 @@ action "initialize_v2_1" "evm::call_contract" {
 }
 
 action "initialize_v2_2" "evm::call_contract" {
-    contract_address = action.deploy_fiat_token.contract_address
-    contract_abi = action.deploy_fiat_token.abi
+    description = "Call the initializeV2_2 function of the FiatToken contract via the proxy"
+    contract_address = action.deploy_fiat_token_proxy.contract_address
+    contract_abi = variable.fiat_token_contract.abi
     function_name = "initializeV2_2"
     function_args = [
         [],

--- a/runbooks/deployments/deploy-fiat-token/main.tx
+++ b/runbooks/deployments/deploy-fiat-token/main.tx
@@ -1,0 +1,102 @@
+addon "evm" {
+    rpc_api_url = input.rpc_api_url
+    chain_id = input.chain_id
+}
+
+signer "deployer" "evm::secret_key" {
+    secret_key = input.deployer_secret_key
+}
+
+action "deploy_fiat_token_proxy" "evm::deploy_contract" {
+    contract = evm::get_contract_from_foundry_project("FiatTokenProxy")
+    constructor_args = [
+        variable.fiat_token_v2_2_address
+    ]
+    signer = signer.deployer
+}
+
+action "deploy_master_minter" "evm::deploy_contract" {
+    contract = evm::get_contract_from_foundry_project("MasterMinter")
+    constructor_args = [
+        action.deploy_fiat_token_proxy.contract_address
+    ]
+    signer = signer.deployer
+}
+
+action "transfer_minter_ownership" "evm::call_contract" {
+    contract_address = action.deploy_master_minter.contract_address
+    contract_abi = action.deploy_master_minter.abi
+    function_name = "transferOwnership"
+    function_args = [
+        evm::address(input.master_minter_owner)
+    ]
+    signer = signer.deployer
+}
+
+action "change_proxy_admin" "evm::call_contract" {
+    contract_address = action.deploy_fiat_token_proxy.contract_address
+    contract_abi = action.deploy_fiat_token_proxy.abi
+    function_name = "changeAdmin"
+    function_args = [
+        evm::address(input.proxy_admin)
+    ]
+    signer = signer.deployer
+}
+
+action "deploy_fiat_token" "evm::deploy_contract" {
+    contract = evm::get_contract_from_foundry_project(variable.fiat_token_contract_name)
+    signer = signer.deployer
+
+}
+
+action "initialize" "evm::call_contract" {
+    contract_address = action.deploy_fiat_token.contract_address
+    contract_abi = action.deploy_fiat_token.abi
+    function_name = "initialize"
+    function_args = [
+        input.token_name,
+        input.token_symbol,
+        input.token_currency,
+        evm::uint8(input.token_decimals),
+        action.deploy_master_minter.contract_address,
+        evm::address(input.pauser),
+        evm::address(input.blacklister),
+        evm::address(input.owner)
+    ]
+    signer = signer.deployer
+    // depends_on = [action.deploy_fiat_token]
+}
+
+action "initialize_v2" "evm::call_contract" {
+    contract_address = action.deploy_fiat_token.contract_address
+    contract_abi = action.deploy_fiat_token.abi
+    function_name = "initializeV2"
+    function_args = [
+        input.token_name,
+    ]
+    signer = signer.deployer
+    depends_on = [action.initialize]
+}
+
+action "initialize_v2_1" "evm::call_contract" {
+    contract_address = action.deploy_fiat_token.contract_address
+    contract_abi = action.deploy_fiat_token.abi
+    function_name = "initializeV2_1"
+    function_args = [
+        evm::address(input.lost_and_found)
+    ]
+    signer = signer.deployer
+    depends_on = [action.initialize_v2]
+}
+
+action "initialize_v2_2" "evm::call_contract" {
+    contract_address = action.deploy_fiat_token.contract_address
+    contract_abi = action.deploy_fiat_token.abi
+    function_name = "initializeV2_2"
+    function_args = [
+        [],
+        input.token_symbol
+    ]
+    signer = signer.deployer
+    depends_on = [action.initialize_v2_1]
+}

--- a/runbooks/deployments/deploy-fiat-token/setup.celo-devnet.tx
+++ b/runbooks/deployments/deploy-fiat-token/setup.celo-devnet.tx
@@ -1,0 +1,30 @@
+action "deploy_fiat_token_celo_v2_2" "evm::deploy_contract" {
+    contract = evm::get_contract_from_foundry_project("FiatTokenCeloV2_2")
+    signer = signer.deployer
+}
+
+action "initialize_fiat_token_v2" "evm::call_contract" {
+    contract_address = action.deploy_fiat_token_celo_v2_2.contract_address
+    contract_abi = action.deploy_fiat_token_celo_v2_2.abi
+    function_name = "initialize"
+    function_args = [
+        "",
+        "",
+        "",
+        evm::uint8(0),
+        variable.throwaway_address,
+        variable.throwaway_address,
+        variable.throwaway_address,
+        variable.throwaway_address,
+    ]
+    signer = signer.deployer
+}
+
+variable "fiat_token_v2_2_address" {
+    value = action.deploy_fiat_token_celo_v2_2.contract_address
+    depends_on = [action.initialize_fiat_token_v2]
+}
+
+variable "fiat_token_contract_name" {
+  value = "FiatTokenCeloV2_2"
+}

--- a/runbooks/deployments/deploy-fiat-token/setup.celo-devnet.tx
+++ b/runbooks/deployments/deploy-fiat-token/setup.celo-devnet.tx
@@ -1,9 +1,16 @@
+variable "fiat_token_contract" {
+    description = "The FiatTokenCeloV2_2 contract & artifacts"
+    value = evm::get_contract_from_foundry_project("FiatTokenCeloV2_2")
+}
+
 action "deploy_fiat_token_celo_v2_2" "evm::deploy_contract" {
-    contract = evm::get_contract_from_foundry_project("FiatTokenCeloV2_2")
+    description = "Deploy the FiatTokenCeloV2_2 contract"
+    contract = variable.fiat_token_contract
     signer = signer.deployer
 }
 
 action "initialize_fiat_token_v2" "evm::call_contract" {
+    description = "Initialize the FiatTokenCeloV2_2 contract with empty values"
     contract_address = action.deploy_fiat_token_celo_v2_2.contract_address
     contract_abi = action.deploy_fiat_token_celo_v2_2.abi
     function_name = "initialize"
@@ -21,10 +28,7 @@ action "initialize_fiat_token_v2" "evm::call_contract" {
 }
 
 variable "fiat_token_v2_2_address" {
+    description = "The address of the FiatTokenCeloV2_2 contract"
     value = action.deploy_fiat_token_celo_v2_2.contract_address
     depends_on = [action.initialize_fiat_token_v2]
-}
-
-variable "fiat_token_contract_name" {
-  value = "FiatTokenCeloV2_2"
 }

--- a/runbooks/deployments/deploy-fiat-token/setup.celo-mainnet.tx
+++ b/runbooks/deployments/deploy-fiat-token/setup.celo-mainnet.tx
@@ -1,0 +1,7 @@
+variable "fiat_token_v2_2_address" {
+    value = input.fiat_token_celo_implementation_address
+}
+
+variable "fiat_token_contract_name" {
+  value = "FiatTokenCeloV2_2"
+}

--- a/runbooks/deployments/deploy-fiat-token/setup.celo-mainnet.tx
+++ b/runbooks/deployments/deploy-fiat-token/setup.celo-mainnet.tx
@@ -1,7 +1,9 @@
 variable "fiat_token_v2_2_address" {
+    description = "The address of the FiatTokenCeloV2_2 contract"
     value = input.fiat_token_celo_implementation_address
 }
 
-variable "fiat_token_contract_name" {
-  value = "FiatTokenCeloV2_2"
+variable "fiat_token_contract" {
+    description = "The FiatTokenCeloV2_2 contract & artifacts"
+    value = evm::get_contract_from_foundry_project("FiatTokenCeloV2_2")
 }

--- a/runbooks/deployments/deploy-fiat-token/setup.fiat-devnet.tx
+++ b/runbooks/deployments/deploy-fiat-token/setup.fiat-devnet.tx
@@ -1,0 +1,30 @@
+action "deploy_fiat_token_v2" "evm::deploy_contract" {
+    contract = evm::get_contract_from_foundry_project("FiatTokenV2_2")
+    signer = signer.deployer
+}
+
+action "initialize_fiat_token_v2" "evm::call_contract" {
+    contract_address = action.deploy_fiat_token_v2.contract_address
+    contract_abi = action.deploy_fiat_token_v2.abi
+    function_name = "initialize"
+    function_args = [
+        "",
+        "",
+        "",
+        evm::uint8(0),
+        variable.throwaway_address,
+        variable.throwaway_address,
+        variable.throwaway_address,
+        variable.throwaway_address,
+    ]
+    signer = signer.deployer
+}
+
+variable "fiat_token_v2_2_address" {
+    value = action.deploy_fiat_token_v2.contract_address
+    depends_on = [action.initialize_fiat_token_v2]
+}
+
+variable "fiat_token_contract_name" {
+  value = "FiatTokenV2_2"
+}

--- a/runbooks/deployments/deploy-fiat-token/setup.fiat-devnet.tx
+++ b/runbooks/deployments/deploy-fiat-token/setup.fiat-devnet.tx
@@ -1,9 +1,16 @@
+variable "fiat_token_contract" {
+    description = "The FiatTokenV2_2 contract & artifacts"
+    value = evm::get_contract_from_foundry_project("FiatTokenV2_2")
+}
+
 action "deploy_fiat_token_v2" "evm::deploy_contract" {
-    contract = evm::get_contract_from_foundry_project("FiatTokenV2_2")
+    description = "Deploy the FiatTokenV2_2 contract"
+    contract = variable.fiat_token_contract
     signer = signer.deployer
 }
 
 action "initialize_fiat_token_v2" "evm::call_contract" {
+    description = "Initialize the FiatTokenV2_2 contract with empty values"
     contract_address = action.deploy_fiat_token_v2.contract_address
     contract_abi = action.deploy_fiat_token_v2.abi
     function_name = "initialize"
@@ -21,10 +28,7 @@ action "initialize_fiat_token_v2" "evm::call_contract" {
 }
 
 variable "fiat_token_v2_2_address" {
+    description = "The address of the FiatTokenV2_2 contract"
     value = action.deploy_fiat_token_v2.contract_address
     depends_on = [action.initialize_fiat_token_v2]
-}
-
-variable "fiat_token_contract_name" {
-  value = "FiatTokenV2_2"
 }

--- a/runbooks/deployments/deploy-fiat-token/setup.fiat-mainnet.tx
+++ b/runbooks/deployments/deploy-fiat-token/setup.fiat-mainnet.tx
@@ -1,7 +1,9 @@
 variable "fiat_token_v2_2_address" {
+    description = "The address of the FiatTokenV2_2 contract"
     value = input.fiat_token_implementation_address
 }
 
-variable "fiat_token_contract_name" {
-  value = "FiatTokenV2_2"
+variable "fiat_token_contract" {
+    description = "The FiatTokenV2_2 contract & artifacts"
+    value = evm::get_contract_from_foundry_project("FiatTokenV2_2")
 }

--- a/runbooks/deployments/deploy-fiat-token/setup.fiat-mainnet.tx
+++ b/runbooks/deployments/deploy-fiat-token/setup.fiat-mainnet.tx
@@ -1,0 +1,7 @@
+variable "fiat_token_v2_2_address" {
+    value = input.fiat_token_implementation_address
+}
+
+variable "fiat_token_contract_name" {
+  value = "FiatTokenV2_2"
+}

--- a/runbooks/deployments/deploy-fiat-token/variables.tx
+++ b/runbooks/deployments/deploy-fiat-token/variables.tx
@@ -1,0 +1,3 @@
+variable "throwaway_address" {
+  value = evm::address("0x1111111111111111111111111111111111111111")
+}

--- a/txtx.yml
+++ b/txtx.yml
@@ -1,0 +1,81 @@
+---
+name: Circle's Stablecoin EVM Contracts
+id: circles-stablecoin-evm-contracts
+runbooks:
+  - name: deploy
+    id: deploy
+    description: Deploys the Fiat Token or Fiat Token Celo contracts. Use environment CLI args to specify the network + contracts to deploy.
+    location: runbooks/deployments/deploy-fiat-token
+    state:
+      location: runbooks/deployments/deploy-fiat-token/state
+environments:
+  fiat-devnet:
+    # network parameters
+    rpc_api_url: http://localhost:8545
+    chain_id: 1
+    # wallet parameters
+    deployer_secret_key: 708c8e68f7cfc670783d848790a5503fb0a83580911760ca5762536bc0628969
+    # contract parameters
+    master_minter_owner: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    proxy_admin: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    token_name: USDC
+    token_symbol: USDC
+    token_currency: USD
+    token_decimals: 6
+    pauser: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    blacklister: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    owner: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    lost_and_found: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+  fiat-mainnet:
+    # network parameters
+    rpc_api_url:
+    chain_id: 1
+    # wallet parameters
+    deployer_secret_key:
+    # contract parameters
+    master_minter_owner:
+    proxy_admin:
+    token_name: USDC
+    token_symbol: USDC
+    token_currency: USD
+    token_decimals: 6
+    pauser:
+    blacklister:
+    owner:
+    fiat_token_implementation_address:
+    lost_and_found:
+  celo-devnet:
+    # network parameters
+    rpc_api_url: http://localhost:8546
+    chain_id: 42220
+    # wallet parameters
+    deployer_secret_key: 708c8e68f7cfc670783d848790a5503fb0a83580911760ca5762536bc0628969
+    # contract parameters
+    master_minter_owner: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    proxy_admin: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    token_name: USBC
+    token_symbol: USBC
+    token_currency: USD
+    token_decimals: 6
+    pauser: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    blacklister: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    owner: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+    lost_and_found: 0xCe246168E59dd8e28e367BB49b38Dc621768F425
+  celo-mainnet:
+    # network parameters
+    rpc_api_url:
+    chain_id: 42220
+    # wallet parameters
+    deployer_secret_key: 0x
+    # contract parameters
+    master_minter_owner:
+    proxy_admin:
+    token_name: USDC
+    token_symbol: USDC
+    token_currency: USD
+    token_decimals: 6
+    pauser:
+    blacklister:
+    owner:
+    fiat_token_celo_implementation_address:
+    lost_and_found:


### PR DESCRIPTION
<p align="center">
  <a href="https://www.youtube.com/watch?v=JO70H6bzfQ4">
      <img src="https://github.com/user-attachments/assets/78c13254-1d9b-4059-a504-6fd501aab0ab" alt="Txtx" width="320" height="180" style="max-width: 100%;">
  </a>
</p>

Hi, I'm Micaiah! 👋

After spending some years shipping developer tools at ConsenSys, I created txtx to fix some problems I've seen in the current Ethereum development workflow.

Note: This runbook is focusing on your EVM deployments but can also support SVM. 

## Summary

We're working to improve deployments & operations of smart contracts across the web3 ecosystem. We'd love for you to be a part of it.

This PR implements a smart contract Runbooks for the `FiatTokenV2_2`/`FiatTokenCeloV2_2` contracts. A tour of the Runbooks can be found [here](https://www.youtube.com/watch?v=JO70H6bzfQ4&list=PL0FMgRjJMRzOTfq3DAtqcGEduYv4GZ2XV&index=2). If this upgrade is interesting to you, we can implement similar Runbooks for the `deploy-fee-adapter.s.sol`, `deploy-impl-and-upgrader.s.sol`, and `deploy-master-minter.s.sol` scripts.

## Detail

We're working on developer tooling that aims to improve the deployments & operations lifecycle of smart contracts.
We see ourselves as the perfect companion for Hardhat and Foundry.

We've worked with teams to ease the burden of deploying contracts to the ever-growing list of L2s and to improve the security of their deployments by enabling multisig and hardware wallet signing of deployment transactions.

We're doing this through a new primitive called "Smart Contract Runbooks". These Runbooks borrow heavily from Terraform; they provide a declarative way to describe your deployments & operations - allowing you to describe the "what" without having to worry about the "how". Txtx is a CLI tool that can be used to execute these Runbooks.

We're currently looking to onboard additional users. We have so many ideas for ways to continue improving the deployment & operations process, and we'd love to work with more teams like Circle to have feedback on the next features!

This PR creates Runbooks that replace the existing `deploy-fiat-token-celo.s.sol` and `deploy-fiat-token.s.sol` scripts. The new Runbooks offer a few advantages over the existing scripts:


<details>
<summary>Simplicity</summary>
Txtx allows for removal of the logic that needs to be managed in the scripts. 

For example, the existing scripts have logic to deploy the token contracts if an `address(0)` is passed into the function, and to return the existing contract otherwise. This same logic is applied for the fiat token and Celo contracts, though the actual contract calls are nearly identical for each.

With txtx, that logic is easily abstracted away with environments - certain environments will deploy the dependencies for you, and others will use the pre-deployed contracts. This allows for the removal of a lot of duplicate code.
</details>


<details>
<summary>Security</summary>
Txtx allows you to specify a web wallet to sign all transactions, so you can stop copy/pasting your keys.
</details>



<details>
<summary>Dependency Analysis</summary>
Txtx uses your Runbook to create a graph of your contracts, so it can automatically detect what contracts need to be redeployed if an upstream contract is updated.
</details>


<details>
<summary> More to Come</summary>
We have so many ideas on improving the deployments & operations phase of development - cost analysis, wallet provisioning, alternate signer types (secure enclaves, keystores, etc), CI integrations, etc, etc.
We'd love for your team to be a part of what's next!
</details>


A tour of Txtx and your Runbooks can be found [here](https://www.youtube.com/watch?v=JO70H6bzfQ4&list=PL0FMgRjJMRzOTfq3DAtqcGEduYv4GZ2XV&index=2).

## Testing
See the video for details, but in short:
```sh
brew tap txtx/txtx
brew install txtx
txtx run deploy --env fiat-devnet -u
```

---

**Requested Reviewers:** @mention
